### PR TITLE
fix: correct semver compare and cross-year date matching

### DIFF
--- a/src/api_post.py
+++ b/src/api_post.py
@@ -7,6 +7,22 @@ from fastmcp import FastMCP
 from utils import _call_ptt_service
 
 
+def parse_date_str(date_str: str) -> datetime:
+    # Add a dummy year to make it a full date for comparison.
+    # Assuming all dates are within the current year for simplicity.
+    # For cross-year comparisons, more complex logic would be needed.
+
+    if date_str.count('/') == 2:
+        return datetime.strptime(date_str, "%Y/%m/%d")
+
+    current_year = datetime.now().year
+    return datetime.strptime(f"{current_year}/{date_str}", "%Y/%m/%d")
+
+
+def _md(d: datetime):
+    return (d.month, d.day)
+
+
 def register_tools(mcp: FastMCP, memory_storage: Dict[str, Any], version: str):
     @mcp.tool()
     def get_board_rules() -> Dict[str, Any]:
@@ -53,23 +69,13 @@ def register_tools(mcp: FastMCP, memory_storage: Dict[str, Any], version: str):
                             失敗時: {'success': False, 'message': str}
         """
 
-        # Helper to parse and compare dates
-        def parse_date_str(date_str: str) -> datetime:
-            # Add a dummy year to make it a full date for comparison.
-            # Assuming all dates are within the current year for simplicity.
-            # For cross-year comparisons, more complex logic would be needed.
-
-            if date_str.count('/') == 2:
-                return datetime.strptime(date_str, "%Y/%m/%d")
-
-            current_year = datetime.now().year
-            return datetime.strptime(f"{current_year}/{date_str}", "%Y/%m/%d")
-
         try:
             target_date = parse_date_str(target_date_str)
         except ValueError:
             return {"success": False,
                     "message": f"Invalid target_date_str format: {target_date_str}. Expected 'YYYY/MM/DD'."}
+
+        # ponytail: 只比對 month/day（PTT list_date 無年份）。若目標日期區間跨年（12月→1月），binary search 的單調性會被打破、結果可能不對；需要跨年支援時得改用文章 header 的完整日期。
 
         # 1. Get the newest index for the board
         newest_index_response = _call_ptt_service(
@@ -115,9 +121,9 @@ def register_tools(mcp: FastMCP, memory_storage: Dict[str, Any], version: str):
                 low = mid + 1
                 continue
 
-            if post_date < target_date:
+            if _md(post_date) < _md(target_date):
                 low = mid + 1
-            elif post_date == target_date:
+            elif _md(post_date) == _md(target_date):
                 start_index = mid
                 high = mid - 1  # Try to find an earlier one
             else:  # post_date > target_date
@@ -148,9 +154,9 @@ def register_tools(mcp: FastMCP, memory_storage: Dict[str, Any], version: str):
                 low = mid + 1
                 continue
 
-            if post_date > target_date:
+            if _md(post_date) > _md(target_date):
                 high = mid - 1
-            elif post_date == target_date:
+            elif _md(post_date) == _md(target_date):
                 end_index = mid
                 low = mid + 1  # Try to find a later one
             else:  # post_date < target_date
@@ -168,8 +174,8 @@ def register_tools(mcp: FastMCP, memory_storage: Dict[str, Any], version: str):
                 index=start_index,
                 query=True,
             )
-            if not start_post_response.get('success') or not start_post_response.get('data') or parse_date_str(
-                    start_post_response['data'].get('list_date', '')) != target_date:
+            if not start_post_response.get('success') or not start_post_response.get('data') or _md(parse_date_str(
+                    start_post_response['data'].get('list_date', ''))) != _md(target_date):
                 return {"success": False,
                         "message": f"在 {board} 板找不到日期 {target_date} 的任何文章 (start_index verification failed)."}
 
@@ -181,8 +187,8 @@ def register_tools(mcp: FastMCP, memory_storage: Dict[str, Any], version: str):
                 index=end_index,
                 query=True,
             )
-            if not end_post_response.get('success') or not end_post_response.get('data') or parse_date_str(
-                    end_post_response['data'].get('list_date', '')) != target_date:
+            if not end_post_response.get('success') or not end_post_response.get('data') or _md(parse_date_str(
+                    end_post_response['data'].get('list_date', ''))) != _md(target_date):
                 return {"success": False,
                         "message": f"在 {board} 板找不到日期 {target_date} 的任何文章 (end_index verification failed)."}
 

--- a/src/auto_version.py
+++ b/src/auto_version.py
@@ -38,6 +38,10 @@ def get_version() -> tuple[Optional[str], Optional[str]]:
     return None, None  # Should not be reached
 
 
+def _version_key(version_str: str) -> tuple:
+    return tuple(int(part) for part in version_str.split('.'))
+
+
 def main():
     remote_version, current_version = get_version()
 
@@ -45,7 +49,7 @@ def main():
         print("Failed to retrieve version information.")
         return
 
-    if int(remote_version.replace('.', '')) <= int(current_version.replace('.', '')):
+    if _version_key(remote_version) <= _version_key(current_version):
         print(current_version)
     else:
         print(remote_version)

--- a/src/test_api_post.py
+++ b/src/test_api_post.py
@@ -2,28 +2,37 @@ import os
 import sys
 import types
 
-# Allow running from the repo root: `python src/test_api_post.py`.
-SRC_DIR = os.path.dirname(os.path.abspath(__file__))
-if SRC_DIR not in sys.path:
-    sys.path.insert(0, SRC_DIR)
 
-# api_post (via utils) imports PyPtt and fastmcp at module load time. Those are
-# heavy runtime deps that may not be installed in a test environment, so stub
-# them out before importing the pure date helpers we actually want to test.
-sys.modules.setdefault("PyPtt", types.ModuleType("PyPtt"))
-if "fastmcp" not in sys.modules:
-    fastmcp_stub = types.ModuleType("fastmcp")
-    fastmcp_stub.FastMCP = object
-    sys.modules["fastmcp"] = fastmcp_stub
+def _load_helpers():
+    # Allow running from the repo root: `python src/test_api_post.py`.
+    src_dir = os.path.dirname(os.path.abspath(__file__))
+    if src_dir not in sys.path:
+        sys.path.insert(0, src_dir)
 
-from api_post import _md, parse_date_str
+    # api_post (via utils) imports PyPtt and fastmcp at module load time. Those
+    # are heavy runtime deps that may not be installed in a test environment, so
+    # stub them out before importing the pure date helpers we want to test.
+    sys.modules.setdefault("PyPtt", types.ModuleType("PyPtt"))
+    if "fastmcp" not in sys.modules:
+        fastmcp_stub = types.ModuleType("fastmcp")
+        setattr(fastmcp_stub, "FastMCP", object)
+        sys.modules["fastmcp"] = fastmcp_stub
 
-# A target date carrying a year (e.g. "1987/09/06") must match a yearless PTT
-# list_date ("9/06") once compared via _md(). This was the original broken case.
-assert _md(parse_date_str("1987/09/06")) == _md(parse_date_str("9/06"))
+    from api_post import _md, parse_date_str
 
-assert _md(parse_date_str("6/29")) == (6, 29)
+    return _md, parse_date_str
 
-assert _md(parse_date_str("6/29")) != _md(parse_date_str("6/30"))
 
-print("OK")
+def test_md_compare():
+    _md, parse_date_str = _load_helpers()
+
+    # A target date carrying a year (e.g. "1987/09/06") must match a yearless
+    # PTT list_date ("9/06") once compared via _md(). The original broken case.
+    assert _md(parse_date_str("1987/09/06")) == _md(parse_date_str("9/06"))
+    assert _md(parse_date_str("6/29")) == (6, 29)
+    assert _md(parse_date_str("6/29")) != _md(parse_date_str("6/30"))
+
+
+if __name__ == "__main__":
+    test_md_compare()
+    print("OK")

--- a/src/test_api_post.py
+++ b/src/test_api_post.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import types
+
+# Allow running from the repo root: `python src/test_api_post.py`.
+SRC_DIR = os.path.dirname(os.path.abspath(__file__))
+if SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+# api_post (via utils) imports PyPtt and fastmcp at module load time. Those are
+# heavy runtime deps that may not be installed in a test environment, so stub
+# them out before importing the pure date helpers we actually want to test.
+sys.modules.setdefault("PyPtt", types.ModuleType("PyPtt"))
+if "fastmcp" not in sys.modules:
+    fastmcp_stub = types.ModuleType("fastmcp")
+    fastmcp_stub.FastMCP = object
+    sys.modules["fastmcp"] = fastmcp_stub
+
+from api_post import _md, parse_date_str
+
+# A target date carrying a year (e.g. "1987/09/06") must match a yearless PTT
+# list_date ("9/06") once compared via _md(). This was the original broken case.
+assert _md(parse_date_str("1987/09/06")) == _md(parse_date_str("9/06"))
+
+assert _md(parse_date_str("6/29")) == (6, 29)
+
+assert _md(parse_date_str("6/29")) != _md(parse_date_str("6/30"))
+
+print("OK")

--- a/src/test_auto_version.py
+++ b/src/test_auto_version.py
@@ -1,0 +1,13 @@
+from auto_version import _version_key
+
+
+def test_version_key():
+    assert _version_key("0.3.0") > _version_key("0.2.15")
+    assert _version_key("1.0.0") > _version_key("0.20.0")
+    assert _version_key("0.10.0") > _version_key("0.9.0")
+    assert _version_key("0.3.0") == _version_key("0.3.0")
+
+
+if __name__ == "__main__":
+    test_version_key()
+    print("OK")


### PR DESCRIPTION
## 修掉的 bug

### 1. `auto_version.py` 版本比較錯誤
原本 `int(v.replace('.', ''))` 把點去掉轉 int 不是正確的 semver 比較，各段位數不同時會誤判：
- `0.3.0`→`30` vs `0.2.15`→`215` → 誤判 `0.2.15` 較新
- `1.0.0`→`100` vs `0.20.0`→`200` → 誤判 `0.20.0` 較新

CI 用 `python src/auto_version.py` 的 stdout 決定要不要 rebuild / 打哪個 tag，遲早選錯版本。改用 `_version_key()` 以 int tuple 比較，stdout 行為不變。

### 2. `get_post_index_range` 跨年日期永遠對不上
PTT `list_date` 是無年份的 `M/DD`，`parse_date_str` 一律補當年；若 target 帶非當年年份（docstring 範例就是 `1987/09/06`），`post_date == target_date` 永遠 False → 一律回報「找不到文章」。

改成所有比較只比 `(month, day)`（兩段 binary search + 兩段 verification 全改）。

## 已知上限（已用 `ponytail:` 註解標明，本次不處理）
- 目標日期區間**跨年（12月→1月）**會打破 binary search 單調性，仍不支援；要支援得改用文章 header 的完整日期。
- 刪文/缺號 → `low = mid + 1` 的 best-effort 行為未動。

## 測試
新增純 `assert` self-check，`python src/test_auto_version.py` 與 `python src/test_api_post.py` 皆印 `OK`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)