### PR TITLE
fix: PyPtt.ParameterError 標成 PARAMETER_ERROR，不再誤標 UNKNOWN_ERROR

### DIFF
--- a/src/test_utils.py
+++ b/src/test_utils.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+import pytest
+
+# utils._handle_ptt_exception builds EXCEPTION_MAPPING from real PyPtt exception
+# classes, so it needs the real PyPtt (not the empty stub sibling tests inject).
+# Swap it in, then restore sys.modules so those tests aren't disturbed.
+_SHARED = ("PyPtt", "utils")
+
+
+def test_parameter_error_maps_to_parameter_error_code():
+    src_dir = os.path.dirname(os.path.abspath(__file__))
+    if src_dir not in sys.path:
+        sys.path.insert(0, src_dir)
+    snapshot = {m: sys.modules.get(m) for m in _SHARED}
+    try:
+        if not getattr(sys.modules.get("PyPtt"), "__file__", None):
+            for m in _SHARED:
+                sys.modules.pop(m, None)
+        import PyPtt
+
+        if not hasattr(PyPtt, "ParameterError"):
+            pytest.skip("real PyPtt not installed")
+        import utils
+
+        # ParameterError → 專屬 PARAMETER_ERROR，且保留 PyPtt 的原始訊息。
+        result = utils._handle_ptt_exception(PyPtt.ParameterError("boom"), {})
+        assert result["success"] is False
+        assert result["code"] == "PARAMETER_ERROR"
+        assert "boom" in result["message"]
+
+        # 其他未收錄的例外仍走 UNKNOWN_ERROR（回歸保護）。
+        other = utils._handle_ptt_exception(RuntimeError("x"), {})
+        assert other["code"] == "UNKNOWN_ERROR"
+    finally:
+        for m in _SHARED:
+            mod = snapshot[m]
+            if mod is None:
+                sys.modules.pop(m, None)
+            else:
+                sys.modules[m] = mod
+
+
+if __name__ == "__main__":
+    test_parameter_error_maps_to_parameter_error_code()
+    print("OK")

--- a/src/utils.py
+++ b/src/utils.py
@@ -37,6 +37,10 @@ def _handle_ptt_exception(e: Exception, kwargs: Dict[str, Any]) -> Dict[str, Any
                 else message_format
             )
             return {"success": False, "message": message, "code": code}
+    if isinstance(e, PyPtt.ParameterError):
+        # PyPtt 對參數問題（如 bad_post_type=OTHER 卻沒給 reason、reason 超長）丟
+        # ParameterError，訊息本身就講清楚了；給它專屬 code，別誤標成 UNKNOWN_ERROR。
+        return {"success": False, "message": f"參數錯誤: {e}", "code": "PARAMETER_ERROR"}
     return {
         "success": False,
         "message": f"操作時發生未知錯誤: {e}",


### PR DESCRIPTION
## 問題
`utils._handle_ptt_exception` 的 `EXCEPTION_MAPPING` 沒收錄 `PyPtt.ParameterError`，所以參數類錯誤會落到最後的 fallback、被貼成 `UNKNOWN_ERROR`「操作時發生未知錯誤」——訊息其實有帶到，但 code 誤導。

最典型：`del_post(bad_post_type="OTHER")` 沒給 `bad_post_reason`（PyPtt 丟 `ParameterError`）。

## 修法
在 fallback 前加一條 `ParameterError` 專屬處理，回 `PARAMETER_ERROR` 並保留 PyPtt 原始訊息。**所有工具**的參數錯誤都受惠，不只 del_post；不重複 PyPtt 的驗證邏輯。

## 測試
- 新增 `src/test_utils.py`：`ParameterError → PARAMETER_ERROR`（含原訊息）、其他例外仍走 `UNKNOWN_ERROR`。已驗 fail-before / pass-after。
- `flake8 .` / `mypy .` 全樹綠（＝ CI 內容）、`pytest` 19 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)